### PR TITLE
specify 'bytes' encoding in dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -27,6 +27,12 @@ first_version = 0.05
 
 [@Basic]
 
+; https://contourline.wordpress.com/2015/02/16/non-obvious-fix-to-a-dzil-problem/
+; https://github.com/rjbs/Dist-Zilla/pull/422#
+[Encoding]
+encoding = bytes
+match    = zip
+
 [AutoPrereqs]
 
 [PodWeaver]


### PR DESCRIPTION
This is meant to address the issue noted [here](https://github.com/rjbs/Dist-Zilla/pull/422#): newer `Dist::Zilla` versions will choke on binary files (like `xt/primes1.zip`) unless a `binary` "encoding" is specified to override the `UTF-8` default.

Without the patch, running `dzil build` in the cloned repo produces complaints like this:
```
Could not decode UTF-8 xt/primes1.zip; filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 226); encoded_content added by @Basic/GatherDir (Dist::Zilla::Plugin::GatherDir line 227); error was: UTF-8 "\x8C" does not map to Unicode at /root/.perlbrew/libs/perl-5.35.0@535/lib/perl5/Dist/Zilla/Role/File.pm line 145.
```